### PR TITLE
Defaulting to secure ServerlessWorkflow.io endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "serverless-workflow-vscode-extension",
-	"version": "1.4.0",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "serverless-workflow-vscode-extension",
-	"version": "1.1.0",
+	"version": "1.4.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 				},
 				"swdiagram.diagramserviceurl": {
 					"type": "string",
-					"default": "https://serverlessworkflow.io/services/diagrams/generate",
+					"default": "https://serverlessworkflow.io/services/diagrams",
 					"description": "SW Diagram Service URL"
 				},
 				"swdiagram.transparencygrid": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "serverless-workflow-vscode-extension",
 	"displayName": "Serverless Workflow VSCode Extension",
 	"description": "%description%",
-	"version": "1.4.0",
+	"version": "1.1.0",
 	"icon": "resources/serverlessworkflow-icon-color.png",
 	"publisher": "serverlessworkflow",
 	"author": "Serverless Workflow",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "serverless-workflow-vscode-extension",
 	"displayName": "Serverless Workflow VSCode Extension",
 	"description": "%description%",
-	"version": "1.1.0",
+	"version": "1.4.0",
 	"icon": "resources/serverlessworkflow-icon-color.png",
 	"publisher": "serverlessworkflow",
 	"author": "Serverless Workflow",
@@ -116,7 +116,7 @@
 				},
 				"swdiagram.diagramserviceurl": {
 					"type": "string",
-					"default": "diagram-service-mmagnani.apps.kogito-cloud.automation.rhmw.io",
+					"default": "https://serverlessworkflow.io/services/diagrams/generate",
 					"description": "SW Diagram Service URL"
 				},
 				"swdiagram.transparencygrid": {

--- a/src/commands/showPreview.ts
+++ b/src/commands/showPreview.ts
@@ -65,7 +65,7 @@ function getSvgData(url = '', datalength = 0, data = '', ctype = '') {
     resSvg = '';
     const options = {
         hostname: url,
-        path: '/swdiagram',
+        path: '',
         method: 'POST',
         headers: {
             'Content-Type': ctype,


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
In this PR, we default the diagram generation service call to a secure endpoint using our URL instead of the generated service one. It depends on https://github.com/serverlessworkflow/serverlessworkflow.github.io/pull/51.

**Special notes for reviewers**:
I've bumped the version for testing reasons. Not sure how we should do it, maybe automating in the future. 