### PR TITLE
Publish extension to GH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release artifact
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install VSCE
+        run: npm install -g @vscode/vsce
+
+      - name: Restore dependencies
+        run: npm ci
+
+      - name: Build Extension
+        run: vsce package
+
+      - name: Publish to GitHub
+        uses: softprops/action-gh-release@v2
+        with:
+          files: "*.vsix"


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
As requested in #28, publish the extension on GitHub on release.

**Special notes for reviewers**:
There is no link between the release tag and the version of the extension. The version of the extension is defined in the `package.json` file.

**Additional information (if needed):**